### PR TITLE
Proposed fix for fragment identifier confusion

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -225,6 +225,7 @@ describe("hashable.hash()", function() {
       })
       .enable();
     window.location.hash = "foo";
+    process.nextTick(hash.disable);
   });
 
   wit("should change the hash", function(done) {
@@ -257,6 +258,7 @@ describe("hashable.hash()", function() {
       })
       .enable();
     window.location.hash = "path/to/foo?bar=qux";
+    process.nextTick(hash.disable);
   });
 
   wit("should get the hash right on check()", function(done) {
@@ -269,6 +271,43 @@ describe("hashable.hash()", function() {
       .change(function(e) {
         assert.equal(e.data.name, "shawn");
         done();
+      })
+      .check();
+  });
+
+  wit("should rewrite invalid fragment identifiers (by default)", function(done) {
+    window.location.hash = "foo";
+
+    var div = window.document.createElement("div");
+    div.id = "foo";
+    window.document.querySelector("body").appendChild(div);
+
+    var hash = window.hashable.hash()
+      .format("name/{name}")
+      .default({
+        name: "shawn"
+      })
+      .change(function(e) {
+        if (!e.data || e.data.name !== "shawn") {
+          throw "We should have data here: " + e.url;
+        }
+        done();
+      })
+      .check();
+  });
+
+  wit("shouldn't rewrite valid fragment identifiers", function(done) {
+    window.location.hash = "foo";
+
+    var div = window.document.createElement("div");
+    div.id = "foo";
+    window.document.querySelector("body").appendChild(div);
+
+    var hash = window.hashable.hash()
+      .format("name/{name}")
+      .valid(window.hashable.validFragment)
+      .change(function(e) {
+        if (e.url === "foo" && !e.data) done();
       })
       .check();
   });


### PR DESCRIPTION
This PR proposes a fix for #4, by adding `hashable.hash()#valid()`, which provides a way to tell the hash change handler _not_ to overwrite the hash if it doesn't match its format. The `hashable.validFragment()` function can be provided as the validation function to skip rewriting the hash if an element exists on the page with the fragment identifier listed in the hash. In other words, to create a custom hash handler with a custom format that also respects links to elements on the page, you would do this:

``` html
<div id="help">...</div>
<script>
var hash = hashable.hash()
  .format("widgets/{widget}")
  .valid(hashable.validFragment)
  .default({
    widget: "foo"
  })
  .change(function(e) {
  })
  .check();
</script>
```

In this case, if `location.hash === "#help"`, the change handler should trigger and `e.data` will be `null`; if `location.hash` matches the format `widgets/{widget}`, then `e.data.widget` should have a value; otherwise the default value will be used, the hash will be changed to `#widget/foo`, and the callback should get `e.data.widget === "foo"`.
