### PR TITLE
add hashable.router()

### DIFF
--- a/hashable.js
+++ b/hashable.js
@@ -374,8 +374,10 @@
           var parts = bit.split("="),
               key = decode(parts[0]),
               val = bit.substr(key.length + 1);
-          if (parts.length === 1) {
+          if (parts.length === 1 || val === "true") {
             data[key] = true;
+          } else if (val === "false") {
+            data[key] = false;
           } else {
             data[key] = decode(val);
           }

--- a/test/test.js
+++ b/test/test.js
@@ -458,7 +458,7 @@ describe("hashable.router()", function() {
     assert.deepEqual(router.parse("foo/2"), {bar: 2});
   });
 
-  it("should parse and format multiple routes", function(done) {
+  it("should parse and format multiple routes", function() {
     var router = hashable.router()
       .add("foo/{bar}", function() {})
       .add("foo/{bar}/children", {children: true}, function() {});
@@ -466,7 +466,20 @@ describe("hashable.router()", function() {
     assert.equal(router.format({bar: 1}), "foo/1");
     assert.deepEqual(router.parse("foo/2"), {bar: 2});
     assert.deepEqual(router.parse("foo/4/children"), {bar: 4, children: true});
-    done();
+  });
+
+  it("should do what I tell it to", function() {
+    var router = hashable.router()
+      .add("widgets/{widget}")
+      .add("widgets/{widget}/{size}")
+      .add("widgets/{widget}/{size}/detail", {detail: true});
+
+    assert.deepEqual(router.parse("widgets/foo"), {widget: "foo"});
+    assert.deepEqual(router.parse("widgets/foo/small"), {widget: "foo", size: "small"});
+    assert.deepEqual(router.parse("widgets/foo/small/detail"), {widget: "foo", size: "small", detail: true});
+    assert.equal(router.format({widget: "foo"}), "widgets/foo");
+    assert.equal(router.format({widget: "foo", size: "medium"}), "widgets/foo/medium");
+    assert.equal(router.format({widget: "foo", size: "medium", detail: true}),"widgets/foo/medium/detail");
   });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,13 @@ describe("hashable.qs", function() {
       });
     });
 
+    it("should parse boolean values correctly", function() {
+      assert.deepEqual(qs.parse("foo=true&bar=false"), {
+        foo: true,
+        bar: false
+      });
+    });
+
     it("should parse no parameter value as true", function() {
       assert.deepEqual(qs.parse("foo=bar&baz"), {
         foo: "bar",
@@ -26,6 +33,31 @@ describe("hashable.qs", function() {
         foo: "",
         bar: true
       });
+    });
+  });
+
+  describe("qs.format()", function() {
+    it("should format stuff correctly", function() {
+      assert.equal(qs.format({
+        foo: 1
+      }), "foo=1");
+      assert.equal(qs.format({
+        foo: 2,
+        bar: true
+      }), "foo=2&bar");
+      assert.equal(qs.format({
+        foo: false,
+        bar: true,
+        baz: 10
+      }), "foo=false&bar&baz=10");
+    });
+
+    it("should sort keys", function() {
+      assert.equal(qs.format({
+        foo: false,
+        baz: 10,
+        bar: true
+      }, true), "bar&baz=10&foo=false");
     });
   });
 


### PR DESCRIPTION
The hashable.router object is useful for defining multiple valid URL formats, and can either be used on its own (via the `format()` and `parse()` methods, or in conjunction with hashable.hash:

``` js
var router = hashable.router()
  .add("widgets/{widget}")
  .add("widgets/{widget}/{size}")
  .add("widgets/{widget}/{size}/detail", {detail: true});
router.parse("widgets/foo"); // {widget: "foo"}
router.parse("widgets/foo/small"); // {widget: "foo", size: "small"}
router.parse("widgets/foo/small/detail"); // {widget: "foo", size: "small", detail: true}
router.format({widget: "foo"}); // "widgets/foo"
router.format({widget: "foo", size: "medium"}); // "widgets/foo/medium"
router.format({widget: "foo", size: "medium", detail: true}); // "widgets/foo/medium/detail"
```

This is experimental, and has some side effects in hashable.format(), namely that the introduction of a "strict" mode means that a formatter will return `null` if any of the data keys in its parsed format is missing (null, undefined, or empty) from the provided data:

``` js
hashable.format("foo/{bar}")({}) === null
hashable.format("foo/{bar}")({bar: null}) === null
hashable.format("foo/{bar}")({bar: ""}) === null
```

Strict mode might be settable later, but I don't see any reason why you'd want to format data with undefined, null or empty keys.
