### PR TITLE
adding percent sign (%) as a valid character within a hashable.format 'w...

### DIFF
--- a/hashable.js
+++ b/hashable.js
@@ -175,7 +175,7 @@
     }
 
     var keys = [],
-        word = "([-\\w\\.]+)",
+        word = "([-\\w\\.\\%]+)",
         wordPattern = new RegExp("{" + word + "}", "g"),
         pattern = new RegExp("^" + fmt.replace(wordPattern, function(_, key) {
           keys.push(key);


### PR DESCRIPTION
I was running into issues storing file names with spaces in the hash object.  Although the filename is url-encoded correctly with `%20`'s, the pattern used by hashable.format to what comprimises a `word` doesn't include a percent sign as a valid character.  The hash will then revert to the default hash, as designed.

This (simple!) change fixes this.
